### PR TITLE
Fix question button on homepage #92

### DIFF
--- a/SA3/qa_web/templates/qa_web/home.html
+++ b/SA3/qa_web/templates/qa_web/home.html
@@ -7,7 +7,7 @@
       <div class="container">
         <h1 class="masthead-heading mb-0">Got Questions</h1>
         <h2 class="masthead-subheading mb-0"> ? !</h2>
-        <a {% if user.is_authenticated %} href="/questions/" {% else %}  href="/login/"  {% endif %} class="btn btn-primary btn-xl rounded-pill mt-5">Click to Ask a Question</a>
+        <a href="/questions/" class="btn btn-primary btn-xl rounded-pill mt-5">Click to Ask a Question</a>
       </div>
     </div>
 


### PR DESCRIPTION
Remove conditional on `href` value of the "Click to ask a question" button found on the homepage. This way the `question` view's redirecting behaviour will occur correctly to ask the user to login.